### PR TITLE
fix: additional parameters appended do not work

### DIFF
--- a/workfinder/search/Landsat.py
+++ b/workfinder/search/Landsat.py
@@ -85,13 +85,13 @@ class Landsat8(BaseWorkFinder):
         order['note'] = f"CS_{get_config('app', 'region')}_regular"
         order['projection'] = projection
 
-        for k, v in order.items():
-            if "_collection" in k:
-                if "source_metadata" not in order[k]["products"]:
-                    order[k]["products"] += ["source_metadata"]
-
-                if "pixel_qa" not in order[k]["products"]:
-                    order[k]["products"] += ["pixel_qa"]
+        # for k, v in order.items():
+        #     if "_collection" in k:
+        #         if "source_metadata" not in order[k]["products"]:
+        #             order[k]["products"] += ["source_metadata"]
+        #
+        #         if "pixel_qa" not in order[k]["products"]:
+        #             order[k]["products"] += ["pixel_qa"]
 
         logging.info(json.dumps(order))
         # POST https://espa.cr.usgs.gov/api/v1/order


### PR DESCRIPTION
Additional parameters called source_metadata and pixel_qa were appended to the order
even if they get available products do not return them.

![image](https://user-images.githubusercontent.com/17437897/200840544-85af03d8-3fcb-4cab-b4ff-e3bc940a0b2b.png)
![image](https://user-images.githubusercontent.com/17437897/200840624-af7107fa-fc58-48f1-aae4-bcffa4b1dd13.png)

This results in broken order.

Removing or adding those parameters fixes the order process and the Redis list gets filled with pending order IDs.
![image](https://user-images.githubusercontent.com/17437897/200840961-ced47bba-0393-493a-b342-6f907de23aa3.png)

Any reason these parameters need to be added in? If yes, could there be a better way of determining they should be in rather than doing string contains?
