### PR TITLE
fix: limit order size and list of available product 

### DIFF
--- a/workfinder/search/Landsat.py
+++ b/workfinder/search/Landsat.py
@@ -85,13 +85,13 @@ class Landsat8(BaseWorkFinder):
         order['note'] = f"CS_{get_config('app', 'region')}_regular"
         order['projection'] = projection
 
-        for k, v in order.items():
-            if "_collection" in k:
-                if "source_metadata" not in order[k]["products"]:
-                    order[k]["products"] += ["source_metadata"]
-
-                if "pixel_qa" not in order[k]["products"]:
-                    order[k]["products"] += ["pixel_qa"]
+        # for k, v in order.items():
+        #     if "_collection" in k:
+        #         if "source_metadata" not in order[k]["products"]:
+        #             order[k]["products"] += ["source_metadata"]
+        #
+        #         if "pixel_qa" not in order[k]["products"]:
+        #             order[k]["products"] += ["pixel_qa"]
 
         logging.info(json.dumps(order))
         # POST https://espa.cr.usgs.gov/api/v1/order

--- a/workfinder/search/__init__.py
+++ b/workfinder/search/__init__.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import geopandas as gpd
 import pandas as pd
 from libcatapult.storage.s3_tools import NoObjectError
-from pystac import Collection
+from pystac import Collection, STAC_IO
 
 from workfinder import get_config
 from workfinder.api.s3 import S3Api
@@ -90,6 +90,7 @@ def list_catalog(s3: S3Api, collection_path: str):
     try:
         catalog_body = s3.get_object_body(collection_path)
         catalog = json.loads(catalog_body.decode('utf-8'))
+        STAC_IO.read_text_method = s3.stac_read_method
         collection = Collection.from_dict(catalog)
         result = [i.id for i in collection.get_items()]
     except NoObjectError:

--- a/workfinder/workfinder.py
+++ b/workfinder/workfinder.py
@@ -56,7 +56,6 @@ processors = {
 @click.option('--limit', default=-1, help='Number records to process', )
 @click.argument("process")
 def main(process, limit):
-    print("Limit is: ", limit)
     param = process.upper()
     if param in processors:
         logging.info(f"starting work search for {param}")
@@ -68,12 +67,8 @@ def main(process, limit):
         if limit > 5000:
             limit = 5000
         logging.info(f"Processing limit is set to {limit}")
-        if limit == 1:
-            reduced_pandas_frame = work.iloc[0:1]
-            processors[param].submit_tasks(reduced_pandas_frame)
-        else:
-            reduced_pandas_frame = work.iloc[0:limit]
-            processors[param].submit_tasks(reduced_pandas_frame)
+        reduced_pandas_frame = work.iloc[0:limit]
+        processors[param].submit_tasks(reduced_pandas_frame)
         logging.info(f"done work search for {param}")
     else:
         logging.error(f"unknown processor type {param}")


### PR DESCRIPTION
1. Commented out hard adding product names to USGS, order process fails if you order products which are not available
2. Changed filtering pandas frame with sample method to proper iloc way which will not return a random selection of items from pandas frame
3. Added alternative stac read method which can be used for crucial protected uri searching