### PR TITLE
Landsat 8 Fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ asyncio-nats-client==0.11.4
 pystac~=0.5.4
 requests
 click
+geopandas

--- a/workfinder/search/__init__.py
+++ b/workfinder/search/__init__.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import time
 
 import requests
 
@@ -66,6 +67,9 @@ def download_ancillary_file(s3: S3Api, name, remote_path):
         logging.info(f'Downloading {remote}')
         s3.fetch_file(remote, local)
         logging.info(f'Downloaded {remote}')
+    elif os.path.getmtime(local) < (time.time() - 604800):
+        logging.info(f'{name} older than a week, re-downloading')
+        s3.fetch_file(remote, local)
     else:
         logging.info(f'{name} already available')
 

--- a/workfinder/search/__init__.py
+++ b/workfinder/search/__init__.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
+from shapely import wkt
 from libcatapult.storage.s3_tools import NoObjectError
 from pystac import Collection
 
@@ -33,9 +34,8 @@ def get_aoi(s3: S3Api, region: str):
     aoi = borders.loc[borders.NAME == region]
     if aoi.empty:
         raise ValueError(f"region \"{region}\" not found in world borders file")
-    envelope = aoi.to_crs(get_crs()).envelope
-    value = envelope.to_crs({"init": "epsg:4326"}).values[0]
-    return value
+    wkt =  aoi.geometry.values[0]
+    return wkt
 
 
 def get_world_borders(s3: S3Api):


### PR DESCRIPTION
Issues now fixed:

Way too many PathRows were being returned due to an AntiMeridian bug wrapping around the world and thinking Fiji loops all the way round
The DF filtering query wasn't even taking the WRS Row into consideration and caused misses across Fiji
Simplicity improvements to the intersects function, no need to convert to an Object that it already is?